### PR TITLE
fix byte 0x92

### DIFF
--- a/board/inc/stm32f4xx.h
+++ b/board/inc/stm32f4xx.h
@@ -8,8 +8,8 @@
   *          is using in the C source code, usually in main.c. This file contains:
   *           - Configuration section that allows to select:
   *              - The STM32F4xx device used in the target application
-  *              - To use or not the peripheral’s drivers in application code(i.e. 
-  *                code will be based on direct access to peripheral’s registers 
+  *              - To use or not the peripheral's drivers in application code(i.e. 
+  *                code will be based on direct access to peripheral's registers 
   *                rather than drivers API), this option is controlled by 
   *                "#define USE_HAL_DRIVER"
   *  


### PR DESCRIPTION
For [#29500](https://github.com/commaai/openpilot/issues/29500) and this [PR](https://github.com/commaai/openpilot/pull/30854). Probably the file was written on a Windows machine using encoding `cp1252`. Having this character (`0x92`) create error while Scanner of SCons was scanning the file as shown below. Needed this change to enable new scons Scanner for warn=all in openpilot. SCons Scanner uses `utf-8` for encoding.

```scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
scons: *** [body/board/bldc-body.o] UnicodeDecodeError : 'utf-8' codec can't decode byte 0x92 in position 576: invalid start byte
scons: building terminated because of errors.```